### PR TITLE
fix: unhandled rejection in Loader.image()

### DIFF
--- a/src/constructor.js
+++ b/src/constructor.js
@@ -24,24 +24,18 @@ const Potrace = function (image, options) {
 };
 
 Potrace.prototype = {
-    trace: function () {
-        return new Promise(async (resolve, reject) => {
-            try {
-                var info = this.options.all();
-                var load = new Loader(this.dom);
-                this.image = await load.image(this.image);
-                this.canvas = load.canvas(this.image);
-                this.bitmap = load.bitmap(this.canvas, info);
-                this.bitmap.pathlist(this.pathlist);
-                var process = new Processor(info, this.pathlist);
-                process.init();
-                var svg = new Svg(info, this.pathlist, this.bitmap);
-                var traced = svg.get();
-                resolve(traced);
-            } catch (err) {
-                reject(err);
-            }
-        });
+    trace: async function () {
+        var info = this.options.all();
+        var load = new Loader(this.dom);
+        this.image = await load.image(this.image);
+        this.canvas = load.canvas(this.image);
+        this.bitmap = load.bitmap(this.canvas, info);
+        this.bitmap.pathlist(this.pathlist);
+        var process = new Processor(info, this.pathlist);
+        process.init();
+        var svg = new Svg(info, this.pathlist, this.bitmap);
+        var traced = svg.get();
+        return traced;
     },
 };
 

--- a/src/constructor.js
+++ b/src/constructor.js
@@ -5,7 +5,6 @@ const Loader = require("./loader");
 const Option = require("./option");
 const { JSDOM } = require("jsdom");
 const is = require("oslllo-validator");
-const EventEmitter = require("events");
 const Processor = require("./processor");
 const constants = require("./constants");
 

--- a/src/loader.js
+++ b/src/loader.js
@@ -9,30 +9,33 @@ const Loader = function (dom) {
     this.document = dom.window.document;
 };
 
+const base64ToImage = (document, base64) => new Promise((resolve) => {
+    var element = document.createElement("img");
+    element.onload = () => {
+        var data = {
+            file: image,
+            base64: base64,
+            element: element,
+        };
+        resolve(data);
+    };
+    element.src = base64;
+});
+
 Loader.prototype = {
-    image: function (image) {
-        return new Promise(async (resolve, reject) => {
-            if (!is.buffer(image) && !is.string(image)) {
-                var err = error.invalidParameterError(
-                    "image",
-                    "buffer or path to image",
-                    image
-                );
-                return reject(err);
-            }
-            var element = this.document.createElement("img");
-            image = await jimp.read(image);
-            var base64 = await image.getBase64Async(jimp.AUTO);
-            element.onload = () => {
-                var data = {
-                    file: image,
-                    base64: base64,
-                    element: element,
-                };
-                resolve(data);
-            };
-            element.src = base64;
-        });
+    image: async function (image) {
+        if (!is.buffer(image) && !is.string(image)) {
+            var err = error.invalidParameterError(
+                "image",
+                "buffer or path to image",
+                image
+            );
+            throw err;
+        }
+        image = await jimp.read(image);
+        var base64 = await image.getBase64Async(jimp.AUTO);
+        var element = await base64ToImage(this.document, base64);
+        return element;
     },
     canvas: function (image) {
         var { element } = image;

--- a/src/loader.js
+++ b/src/loader.js
@@ -12,12 +12,7 @@ const Loader = function (dom) {
 const base64ToImage = (document, base64) => new Promise((resolve) => {
     var element = document.createElement("img");
     element.onload = () => {
-        var data = {
-            file: image,
-            base64: base64,
-            element: element,
-        };
-        resolve(data);
+        resolve(element);
     };
     element.src = base64;
 });
@@ -35,7 +30,11 @@ Loader.prototype = {
         image = await jimp.read(image);
         var base64 = await image.getBase64Async(jimp.AUTO);
         var element = await base64ToImage(this.document, base64);
-        return element;
+        return {
+            file: image,
+            base64: base64,
+            element: element,
+        };;
     },
     canvas: function (image) {
         var { element } = image;

--- a/src/processor.js
+++ b/src/processor.js
@@ -3,10 +3,8 @@
 const Sum = require("./types/Sum");
 const Quad = require("./types/Quad");
 const Opti = require("./types/Opti");
-const Path = require("./types/Path");
 const Point = require("./types/Point");
 const Curve = require("./types/Curve");
-const Bitmap = require("./types/Bitmap");
 
 const Processor = function (info, pathlist) {
     this.info = info;

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -7,3 +7,4 @@ prepare();
 require("./src/test.example");
 require("./src/test.function");
 require("./src/test.output");
+require("./src/test.loader.error");

--- a/test/src/index.js
+++ b/test/src/index.js
@@ -7,6 +7,14 @@ function prepare() {
     ["generated"].forEach((directory) => {
         fs.emptyDirSync(path2[directory]);
     });
+
+    /*
+     * Throw when hit unhandledRejection, see:
+     * https://github.com/mochajs/mocha/issues/2640#issuecomment-789615757
+     */
+    process.on('unhandledRejection', (reason) => {
+        throw reason;
+    });
 }
 
 module.exports = {

--- a/test/src/test.loader.error.js
+++ b/test/src/test.loader.error.js
@@ -1,0 +1,20 @@
+"use strict";
+
+const { Potrace, assert } = require("./helper");
+
+describe("test.loader.error", () => {
+    describe("new Potrace(404)", () => {
+        it(`throws if loader error`, async () => {
+            let error = null
+
+            try {
+                const image = `./404-not-found.png`
+                await Potrace(image).trace();
+            } catch (e) {
+                error = e
+            }
+
+            assert(error, 'Error should be caught when loader.image() throws')
+        });
+    });
+});


### PR DESCRIPTION
Loader.image() creates promise with async init function.

When [jimp.read()](https://github.com/oslllo/potrace/blob/6623028dcbd3ab8485d17350e8fb13eceace5866/src/loader.js#L24) throws, it will be async error, which cannot caught by [new Promise()](https://github.com/oslllo/potrace/blob/6623028dcbd3ab8485d17350e8fb13eceace5866/src/loader.js#L13).

I refactored Loader.image() into async function, making sure the error will be thrown and caught by caller.

Remaining issue: What should be done with element.onerror(), if any ?